### PR TITLE
抽象クラス作成

### DIFF
--- a/lib/domain/notifiers/auth_notifier.dart
+++ b/lib/domain/notifiers/auth_notifier.dart
@@ -3,6 +3,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import '../repositories/firebase_api_repository.dart';
 
 part 'auth_notifier.freezed.dart';
 
@@ -16,13 +17,15 @@ class AuthState with _$AuthState {
 
 final authNotifierProvider =
     StateNotifierProvider<AuthNotifier, AuthState>((ref) {
-  return AuthNotifier(ref);
+  //firebaseApiRepositoryを注入
+  final firebaseApiRepository = ref.watch(firebaseApiRepositoryProvider);
+  return AuthNotifier(firebaseApiRepository);
 });
 
 class AuthNotifier extends StateNotifier<AuthState> {
-  final Ref ref;
+  final FirebaseApiRepository _firebaseApiRepository;
 
-  AuthNotifier(this.ref) : super(AuthState()) {
+  AuthNotifier(this._firebaseApiRepository) : super(AuthState()) {
     Future.microtask(() {
       _init();
     });
@@ -32,9 +35,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
   final TextEditingController passwordController = TextEditingController();
 
   _init() async {
-    FirebaseAuth.instance
-        .authStateChanges()
-        .listen((User? user) {
+    _firebaseApiRepository.watchAuthState().listen((User? user) {
       if (user == null) {
         state = state.copyWith(isLogin: false);
       } else {
@@ -45,31 +46,30 @@ class AuthNotifier extends StateNotifier<AuthState> {
 
   Future<void> signIn() async {
     try {
-      final result = await FirebaseAuth.instance.createUserWithEmailAndPassword(
-          email: emailController.text, password: passwordController.text);
-      final User? user = result.user;
-      final String uid = user!.uid;
-      state = state.copyWith(currentUser: user);
-      print(state.currentUser);
-      // await createFirestoreUser(uid: uid);
+      final User? user = await _firebaseApiRepository.signIn(
+          emailController.text, passwordController.text
+      );
+      if (user != null) {
+        state = state.copyWith(currentUser: user);
+      }
     } on FirebaseAuthException catch (e) {
       debugPrint(e.toString());
     }
   }
 
   void signOut() async {
-    await FirebaseAuth.instance.signOut();
+    await _firebaseApiRepository.signOut();
     state = state.copyWith(currentUser: null);
   }
 
-  // Future<void> createFirestoreUser({required String uid}) async {
-  //   final FirestoreUser firestoreUser = FirestoreUser(
-  //     email: emailController.text,
-  //     githubUserName: githubUserNameController.text,
-  //     uid: uid,
-  //     githubApiKey: githubApiKeyController.text,
-  //   );
-  //   final Map<String, dynamic> userData = firestoreUser.toJson();
-  //   await FirebaseFirestore.instance.collection("users").doc(uid).set(userData);
-  // }
+// Future<void> createFirestoreUser({required String uid}) async {
+//   final FirestoreUser firestoreUser = FirestoreUser(
+//     email: emailController.text,
+//     githubUserName: githubUserNameController.text,
+//     uid: uid,
+//     githubApiKey: githubApiKeyController.text,
+//   );
+//   final Map<String, dynamic> userData = firestoreUser.toJson();
+//   await FirebaseFirestore.instance.collection("users").doc(uid).set(userData);
+// }
 }

--- a/lib/domain/notifiers/auth_notifier.dart
+++ b/lib/domain/notifiers/auth_notifier.dart
@@ -44,9 +44,9 @@ class AuthNotifier extends StateNotifier<AuthState> {
     });
   }
 
-  Future<void> signIn() async {
+  Future<void> signUp() async {
     try {
-      final User? user = await _firebaseApiRepository.signIn(
+      final User? user = await _firebaseApiRepository.signUp(
           emailController.text, passwordController.text
       );
       if (user != null) {

--- a/lib/domain/repositories/firebase_api_repository.dart
+++ b/lib/domain/repositories/firebase_api_repository.dart
@@ -8,7 +8,7 @@ final firebaseApiRepositoryProvider = Provider<FirebaseApiRepository>((ref) {
 
 abstract class FirebaseApiRepository {
   Stream<User?> watchAuthState();
-  Future<User?> signIn(String email, String password);
+  Future<User?> signUp(String email, String password);
   Future<void> signOut();
 // 他のFirebaseのメソッドもここに追加
 }

--- a/lib/domain/repositories/firebase_api_repository.dart
+++ b/lib/domain/repositories/firebase_api_repository.dart
@@ -1,0 +1,14 @@
+import 'package:beta/infrastructure/firebase_api_repository_impl.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final firebaseApiRepositoryProvider = Provider<FirebaseApiRepository>((ref) {
+  return FirebaseApiRepositoryImpl();
+});
+
+abstract class FirebaseApiRepository {
+  Stream<User?> watchAuthState();
+  Future<User?> signIn(String email, String password);
+  Future<void> signOut();
+// 他のFirebaseのメソッドもここに追加
+}

--- a/lib/infrastructure/firebase_api_repository_impl.dart
+++ b/lib/infrastructure/firebase_api_repository_impl.dart
@@ -8,7 +8,7 @@ class FirebaseApiRepositoryImpl implements FirebaseApiRepository {
   Stream<User?> watchAuthState() => _firebaseAuth.authStateChanges();
 
   @override
-  Future<User?> signIn(String email, String password) async {
+  Future<User?> signUp(String email, String password) async {
     final result = await _firebaseAuth.createUserWithEmailAndPassword(email: email, password: password);
     return result.user;
   }

--- a/lib/infrastructure/firebase_api_repository_impl.dart
+++ b/lib/infrastructure/firebase_api_repository_impl.dart
@@ -1,0 +1,19 @@
+import 'package:beta/domain/repositories/firebase_api_repository.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+class FirebaseApiRepositoryImpl implements FirebaseApiRepository {
+  final FirebaseAuth _firebaseAuth = FirebaseAuth.instance;
+
+  @override
+  Stream<User?> watchAuthState() => _firebaseAuth.authStateChanges();
+
+  @override
+  Future<User?> signIn(String email, String password) async {
+    final result = await _firebaseAuth.createUserWithEmailAndPassword(email: email, password: password);
+    return result.user;
+  }
+
+  @override
+  Future<void> signOut() => _firebaseAuth.signOut();
+
+}

--- a/lib/presentation/page/auth_page/sign_in_page.dart
+++ b/lib/presentation/page/auth_page/sign_in_page.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../domain/notifiers/auth_notifier.dart';
-import '../home_page/home_page.dart';
 
 
 class SignInPage extends ConsumerWidget {

--- a/lib/presentation/page/auth_page/sign_in_page.dart
+++ b/lib/presentation/page/auth_page/sign_in_page.dart
@@ -47,7 +47,7 @@ class SignInPage extends ConsumerWidget {
                 width: 320,
                 child: ElevatedButton(
                   onPressed: () async {
-                    await authNotifier.signIn();
+                    await authNotifier.signUp();
                   },
                   style: ButtonStyle(
                     backgroundColor:


### PR DESCRIPTION
抽象クラスを作成しロジックを実行クラスに移し替えました。
notifier内で _firebaseApiRepository.関数(_firebaseApiRepositoryを_firebaseTestRepositoryや_firebaseMockRepositoryなどに差し替えるだけでテストやモックでの動作確認が容易になります。)